### PR TITLE
add globals to eslint

### DIFF
--- a/Loom/javascript/.eslintrc.yml
+++ b/Loom/javascript/.eslintrc.yml
@@ -6,6 +6,11 @@ extends:
 parserOptions:
   ecmaVersion: latest
   sourceType: module
+globals:
+  inlets: writable
+  outlets: writable
+  post: readable
+  outlet: readable
 rules: {
   no-underscore-dangle: off,
   no-param-reassign: off


### PR DESCRIPTION
Now, Eslint won't complain about things like `inlets = 1` and `post()` being undefined